### PR TITLE
fix denoise setting

### DIFF
--- a/searge_sdxl_sampler_node.py
+++ b/searge_sdxl_sampler_node.py
@@ -72,7 +72,7 @@ class SeargeSDXLSampler:
 
         base_result = nodes.common_ksampler(base_model, noise_seed, steps, cfg, sampler_name, scheduler, base_positive, base_negative, latent_image, denoise=denoise, disable_noise=False, start_step=0, last_step=base_steps, force_full_denoise=False)
 
-        return nodes.common_ksampler(refiner_model, noise_seed, steps, cfg, sampler_name, scheduler, refiner_positive, refiner_negative, base_result[0], denoise=1.0, disable_noise=True, start_step=base_steps, last_step=steps, force_full_denoise=True)
+        return nodes.common_ksampler(refiner_model, noise_seed, steps, cfg, sampler_name, scheduler, refiner_positive, refiner_negative, base_result[0], denoise=denoise, disable_noise=True, start_step=base_steps, last_step=steps, force_full_denoise=True)
 
 
 # SDXL CLIP Text Encoder for prompts with base and refiner support


### PR DESCRIPTION
calling the `common_sampler` with a `denoise < 1.0` will make it expand the noise schedule by `1/denoise` in order to honor both the requested number of steps and the denoise setting. So calling the base with the user given denoise and the refiner with 1.0 will cause a miss match in the noise schedule.

e.g. if a user requests 10 steps, 80% on base, with a denoise of 0.1 the following would happen in the old code: 1) the noise schedule would get expanded to 100 steps, and the base model would run steps 90 to 98, leaving step 99 and 100 to the refiner. 2) the refiner does not expand the schedule to 100 steps, but uses a 10 step schedule, and now runs step 9 and 10, roughly equivalent to step 90 and 100. Thus the refiner expects to get more noise than the base model actually hands over.