### PR TITLE
fixing SDXL Sampler V3 to work with newest version of ComfyUI

### DIFF
--- a/modules/stage_latent_detailer.py
+++ b/modules/stage_latent_detailer.py
@@ -26,7 +26,7 @@ SOFTWARE.
 
 """
 
-from comfy.sample import prepare_mask
+from comfy.sampler_helpers import prepare_mask
 
 from .data_utils import retrieve_parameter
 from .mb_pipeline import PipelineAccess

--- a/modules/stage_latent_detailer.py
+++ b/modules/stage_latent_detailer.py
@@ -25,8 +25,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 """
-
-from comfy.sampler_helpers import prepare_mask
+try:
+    from comfy.sampler_helpers import prepare_mask
+except ImportError:
+    from comfy.sample import prepare_mask
 
 from .data_utils import retrieve_parameter
 from .mb_pipeline import PipelineAccess


### PR DESCRIPTION
As discussed here https://github.com/SeargeDP/SeargeSDXL/issues/137 some of the sampler functions of ComfyUI were moved around, causing SeargeSDXL to no longer load.

After fixing that issue there still were problems with the SDXL Sampler, which led to errors when running that specific module. I managed to get rid of these errors and it seems to work fine for me now. However I'm not very familiar with this project's / ComfyUI's code and have a distaste for python, so please make sure to double check everything I did. 

I also only added backwards compatibility for the loading issue. If you also want it for executing the sampler feel free to add it.

EDIT: The changes from this PR have been added to the main repo. Thanks a lot @SeargeDP 