### PR TITLE
Normalize string for ComfyUI directory matching

### DIFF
--- a/installer/SeargeSDXL-Installer.py
+++ b/installer/SeargeSDXL-Installer.py
@@ -481,7 +481,7 @@ def do_install():
     if running_in_extension_directory:
         print(f"Switched to directory: {os.getcwd()}")
 
-    correct_directory = os.getcwd() == comfy_path
+    correct_directory = os.getcwd().lower() == comfy_path.lower()
     if not correct_directory:
         print("The script is NOT running in the correct directory")
         return False


### PR DESCRIPTION
I used SeargeSDXL-Installer.py to get your workflow and encountered an issue with string matching.
Added prints to debug string variables, and it turns out that the drive letter was different (lower case vs. upper case).

![image](https://github.com/user-attachments/assets/211efda9-059a-427b-8918-05edfb06bf3f)